### PR TITLE
install japanese env

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -10,6 +10,10 @@ RUN sudo apt-get update && \
   sudo apt-get install -y cmake build-essential libssl-dev libffi-dev python3-dev cython && \
   # soundfile
   sudo apt-get install -y libsndfile1 && \
+  sudo apt-get install -y debconf-utils && \
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq language-pack-ja-base language-pack-ja fonts-takao fcitx fcitx-mozc fonts-inconsolata && \
+  echo 'keyboard-configuration keyboard-configuration/variant select Japanese' | sudo debconf-set-selections && \
+  sudo dpkg-reconfigure -f noninteractive -plow keyboard-configuration && \
   sudo apt-get clean && \
   sudo rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## 内容

日本語入力のためのソフトをインストールするように
また、インタラクティブに入力を求めてくるのをやめて、 `dpkg-reconfigure` で設定するように

gitpod 上での mozc での日本語入力への切り替えは、`<ctrl-space>` で行う